### PR TITLE
Fix: ProductRepository query methods for brand field

### DIFF
--- a/src/main/java/com/kali/kali_shops/repository/ProductRepository.java
+++ b/src/main/java/com/kali/kali_shops/repository/ProductRepository.java
@@ -8,9 +8,9 @@ import java.util.List;
 public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findByCategoryName(String category);
 
-    List<Product> findByBrandName(String brand);
+    List<Product> findByBrand(String brand);
 
-    List<Product> findByCategoryNameAndBrandName(String category, String brand);
+    List<Product> findByCategoryNameAndBrand(String category, String brand);
 
     List<Product> findByName(String name);
 

--- a/src/main/java/com/kali/kali_shops/service/product/ProductService.java
+++ b/src/main/java/com/kali/kali_shops/service/product/ProductService.java
@@ -89,12 +89,12 @@ public class ProductService implements IProductService {
 
     @Override
     public List<Product> getProductsByBrand(String brand) {
-        return productRepository.findByBrandName(brand);
+        return productRepository.findByBrand(brand);
     }
 
     @Override
     public List<Product> getProductsByCategoryAndBrand(String category, String brand) {
-        return productRepository.findByCategoryNameAndBrandName(category, brand);
+        return productRepository.findByCategoryNameAndBrand(category, brand);
     }
 
     @Override


### PR DESCRIPTION
- Renamed **`findByCategoryNameAndBrandName`** to **`findByCategoryNameAndBrand`**
- Renamed **`findByBrandName`** to **`findByBrand`**
- **Reason:** The **`brand`** property in **`Product`** is a String field, not an object, so JPA failed when trying to interpret **`BrandName`** as a nested property. The method names referencing **`brandName`** implied a nested property **`(brand.name)`**,  which caused query creation errors.