### PR TITLE
Add missing ModelMapper bean for runtime injection

### DIFF
--- a/src/main/java/com/kali/kali_shops/config/ShopConfig.java
+++ b/src/main/java/com/kali/kali_shops/config/ShopConfig.java
@@ -1,0 +1,14 @@
+package com.kali.kali_shops.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ShopConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}


### PR DESCRIPTION
Adds back the `ModalMapper` bean which is required for Spring's dependency injection at runtime.