### PR TITLE
Remove unnecessary `id` field from AddProductRequest DTO

### DIFF
--- a/src/main/java/com/kali/kali_shops/model/CartItem.java
+++ b/src/main/java/com/kali/kali_shops/model/CartItem.java
@@ -1,5 +1,6 @@
 package com.kali.kali_shops.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,6 +26,7 @@ public class CartItem {
     @JoinColumn(name = "product_id")
     private Product product;
 
+    @JsonIgnore
     @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "cart_id")
     private Cart cart;

--- a/src/main/java/com/kali/kali_shops/request/AddProductRequest.java
+++ b/src/main/java/com/kali/kali_shops/request/AddProductRequest.java
@@ -5,10 +5,8 @@ import lombok.Data;
 
 import java.math.BigDecimal;
 
-// We create this class because it isn't available to work directly with entities or model classes
 @Data
 public class AddProductRequest {
-    private Long id;
     private String name;
     private String brand;
     private BigDecimal unitPrice;


### PR DESCRIPTION
### Changes

- Remove the unused `id` field from the `AddProductRequest` DTO since it is not required when creating a new product.